### PR TITLE
Remove psycopg dependency from local and production requirements

### DIFF
--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -2,7 +2,7 @@
 
 Werkzeug[watchdog]==3.1.3 # https://github.com/pallets/werkzeug
 ipdb==0.13.13  # https://github.com/gotcha/ipdb
-psycopg[c]==3.2.4  # https://github.com/psycopg/psycopg
+# psycopg[c]==3.2.4  # https://github.com/psycopg/psycopg - no need for now coz we are using TiDB
 watchfiles==1.0.4  # https://github.com/samuelcolvin/watchfiles
 
 # Testing

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -3,7 +3,7 @@
 -r base.txt
 
 gunicorn==23.0.0  # https://github.com/benoitc/gunicorn
-psycopg[c]==3.2.4  # https://github.com/psycopg/psycopg
+# psycopg[c]==3.2.4  # https://github.com/psycopg/psycopg - no need for now coz we are using TiDB
 sentry-sdk==2.20.0  # https://github.com/getsentry/sentry-python
 
 # Django


### PR DESCRIPTION
## Description

Remove psycopg dependency from local and production requirements because we are using TiDB