### PR TITLE
Update OTP to Number Only

### DIFF
--- a/accounts/models.py
+++ b/accounts/models.py
@@ -156,7 +156,7 @@ class VerificationCode(models.Model):
             self.create_expired_at()
 
         if not self.code:
-            self.code = get_random_string(length=4)
+            self.code = get_random_string(length=4, allowed_chars="0123456789")
 
         return super().save(*args, **kwargs)
 
@@ -203,7 +203,7 @@ class LoginCode(models.Model):
             self.create_expired_at()
 
         if not self.code:
-            self.code = get_random_string(length=4)
+            self.code = get_random_string(length=4, allowed_chars="0123456789")
 
         return super().save(*args, **kwargs)
 


### PR DESCRIPTION
# Description

This pull request updates the `save` method in the `accounts/models.py` file to ensure that the generated `code` consists only of numeric characters. This change improves the consistency and usability of the `code` field.

Key changes:

* Updated the `get_random_string` function in two instances of the `save` method to include the `allowed_chars="0123456789"` parameter, ensuring that the generated `code` is numeric. (`accounts/models.py`, [[1]](diffhunk://#diff-6b070a300f0e440e2b6e3ae75cd4a54300517cbc9bdbb9a08584f10c026abaa1L159-R159) [[2]](diffhunk://#diff-6b070a300f0e440e2b6e3ae75cd4a54300517cbc9bdbb9a08584f10c026abaa1L206-R206)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Verification and login codes are now generated using digits only, improving consistency and clarity for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->