### PR TITLE
Update Social Media API Permission

### DIFF
--- a/social_media/tests/test_views/test_get_post_list_view.py
+++ b/social_media/tests/test_views/test_get_post_list_view.py
@@ -22,3 +22,14 @@ class TestGetPostListView(TestCase):
         assert len(posts.get("results")) == 15, "Should return 15 posts"  # noqa: PLR2004
         for post in posts.get("results"):
             assert len(post.get("images")) == 3, "Each post should contain 3 images"  # noqa: PLR2004
+
+    def test_get_post_list_unauthenticated(self):
+        self.client.logout()
+        response = self.client.get(self.url)
+        posts = response.json()
+        assert (
+            response.status_code == status.HTTP_200_OK
+        ), "Should allow unauthenticated GET requests"
+        assert len(posts.get("results")) == 15, (  # noqa: PLR2004
+            "Should return 15 posts for unauthenticated user"
+        )

--- a/social_media/views.py
+++ b/social_media/views.py
@@ -44,6 +44,11 @@ class ListCreatePostView(ListCreateAPIView):
     filter_backends = [SearchFilter]
     search_fields = ["content", "user__username"]
 
+    def get_permissions(self):
+        if self.request.method == "GET":
+            return []
+        return [IsAuthenticatedOrReadOnly()]
+
     def get_serializer_class(self):
         if self.request.method == "POST":
             return CreatePostSerializer


### PR DESCRIPTION
# Description

This pull request introduces changes to improve the functionality and accessibility of the `social_media` application. The main updates include adding support for unauthenticated users to view posts and enhancing the test coverage for this feature.

### Enhancements to unauthenticated access:

* [`social_media/views.py`](diffhunk://#diff-c09e75a6f257ac568c03f230a65bc15afcfc6ecba90c30910f0511c9360bc6bbR47-R51): Modified the `ListCreatePostView` class to allow unauthenticated users to make `GET` requests by overriding the `get_permissions` method. This ensures that authentication is only required for non-`GET` methods.

### Test coverage improvements:

* [`social_media/tests/test_views/test_get_post_list_view.py`](diffhunk://#diff-4e565bc44dc5d856bf393013d5fd8e200fc16ec3e5a5f8dd723ccc85bf60cf36R25-R35): Added a new test method, `test_get_post_list_unauthenticated`, to verify that unauthenticated users can successfully retrieve posts and that the response contains the expected number of posts.