### PR TITLE
Adding Get Profile By ID Endpoint

### DIFF
--- a/accounts/urls.py
+++ b/accounts/urls.py
@@ -14,6 +14,11 @@ urlpatterns = [
     path("login/", views.LoginView.as_view(), name="login"),
     path("login/confirm", views.ConfirmLoginView.as_view(), name="confirm-login"),
     path("profile/", views.ProfileView.as_view(), name="profile"),
+    path(
+        "profile/<int:profile_id>/",
+        views.ProfileDetailAPIView.as_view(),
+        name="profile-detail-by-id",
+    ),
 ]
 
 app_name = "accounts"

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -5,6 +5,7 @@ from rest_framework.authentication import SessionAuthentication
 from rest_framework.generics import CreateAPIView
 from rest_framework.generics import GenericAPIView
 from rest_framework.generics import UpdateAPIView
+from rest_framework.generics import RetrieveAPIView
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.views import APIView
@@ -184,3 +185,12 @@ class ProfileView(APIView):
 
         serializer = self.serializer_class(profile)
         return Response(serializer.data)
+
+
+class ProfileDetailAPIView(RetrieveAPIView):
+    queryset = Profile.objects.select_related("user").all()
+    serializer_class = ProfileSerializer
+    authentication_classes = [JWTAuthentication, SessionAuthentication]
+    permission_classes = []  # No permission required to get specific user profile
+    lookup_field = "id"
+    lookup_url_kwarg = "profile_id"

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -4,8 +4,8 @@ from rest_framework import status
 from rest_framework.authentication import SessionAuthentication
 from rest_framework.generics import CreateAPIView
 from rest_framework.generics import GenericAPIView
-from rest_framework.generics import UpdateAPIView
 from rest_framework.generics import RetrieveAPIView
+from rest_framework.generics import UpdateAPIView
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.views import APIView

--- a/config/settings/production.py
+++ b/config/settings/production.py
@@ -204,7 +204,10 @@ sentry_sdk.init(
 # -------------------------------------------------------------------------------
 # Tools that generate code samples can use SERVERS to point to the correct domain
 SPECTACULAR_SETTINGS["SERVERS"] = [
-    {"url": "https://dev.api.taniverse.is", "description": "Taniverse Developmet Server"},
+    {
+        "url": "https://dev.api.taniverse.is",
+        "description": "Taniverse Developmet Server",
+    },
 ]
 # Your stuff...
 # ------------------------------------------------------------------------------

--- a/config/settings/production.py
+++ b/config/settings/production.py
@@ -204,7 +204,7 @@ sentry_sdk.init(
 # -------------------------------------------------------------------------------
 # Tools that generate code samples can use SERVERS to point to the correct domain
 SPECTACULAR_SETTINGS["SERVERS"] = [
-    {"url": "https://example.com", "description": "Production server"},
+    {"url": "https://dev.api.taniverse.is", "description": "Taniverse Developmet Server"},
 ]
 # Your stuff...
 # ------------------------------------------------------------------------------

--- a/config/settings/production.py
+++ b/config/settings/production.py
@@ -206,7 +206,7 @@ sentry_sdk.init(
 SPECTACULAR_SETTINGS["SERVERS"] = [
     {
         "url": "https://dev.api.taniverse.is",
-        "description": "Taniverse Developmet Server",
+        "description": "Taniverse Development Server",
     },
 ]
 # Your stuff...

--- a/scripts/arter.py
+++ b/scripts/arter.py
@@ -1,4 +1,5 @@
 from accounts.tests.factories import ProfileFactory
 
+
 def run():
     ProfileFactory.create_batch(10)

--- a/scripts/arter.py
+++ b/scripts/arter.py
@@ -1,0 +1,4 @@
+from accounts.tests.factories import ProfileFactory
+
+def run():
+    ProfileFactory.create_batch(10)


### PR DESCRIPTION
# Description

This pull request introduces new functionality for retrieving user profile details by ID, updates production server settings, and adds a script for generating test data. The most important changes include adding a new API endpoint for profile details, modifying server configuration, and creating a script for batch profile creation.

### API Enhancements:
* [`accounts/urls.py`](diffhunk://#diff-03dca5d7540fa101a3ff209d6d035f43b1637d2e6c9fbe9ebfe7342637ac3ca9R17-R21): Added a new route `profile/<int:profile_id>/` for retrieving profile details by ID.
* [`accounts/views.py`](diffhunk://#diff-dbd84d60cbc8023306050504e8b3559801fa31ed64b7e967379a5293528b7978R188-R196): Introduced `ProfileDetailAPIView` class to handle retrieving user profile details, including authentication and serializer setup.

### Configuration Updates:
* [`config/settings/production.py`](diffhunk://#diff-b547313c08ca0949c654ff88d1c7f07a56d0f6c3076fa8152ab1243ca402fccaL207-R210): Updated the `SPECTACULAR_SETTINGS["SERVERS"]` configuration to use the Taniverse Development Server URL instead of the example domain.

### Testing and Development:
* [`scripts/arter.py`](diffhunk://#diff-428fca96e354dd0d4f1243e26e4b8b80393d32c6d6fa3a5bf4a5b2de150bdd2dR1-R5): Added a script to generate a batch of 10 test profiles using the `ProfileFactory`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an API endpoint to retrieve profile details by profile ID.
  - Introduced a script to batch-create profile instances for testing or development purposes.

- **Configuration**
  - Updated API documentation settings to reflect a new development server URL and description.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->