### PR TITLE
Update SPECTACULAR_SETTINGS to allow any user access to API documentation

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -374,7 +374,7 @@ SPECTACULAR_SETTINGS = {
     "TITLE": "Tani Pintar API",
     "DESCRIPTION": "Documentation of API endpoints of Tani Pintar",
     "VERSION": "1.0.0",
-    "SERVE_PERMISSIONS": ["rest_framework.permissions.IsAdminUser"],
+    "SERVE_PERMISSIONS": ["rest_framework.permissions.AllowAny"],
     "SCHEMA_PATH_PREFIX": "/api/",
 }
 # Your stuff...

--- a/core/users/tests/test_swagger.py
+++ b/core/users/tests/test_swagger.py
@@ -11,10 +11,10 @@ def test_swagger_accessible_by_admin(admin_client):
 
 
 @pytest.mark.django_db
-def test_swagger_ui_not_accessible_by_normal_user(client):
+def test_swagger_ui_accessible_by_normal_user(client):
     url = reverse("api-docs")
     response = client.get(url)
-    assert response.status_code == HTTPStatus.FORBIDDEN
+    assert response.status_code == HTTPStatus.OK
 
 
 def test_api_schema_generated_successfully(admin_client):


### PR DESCRIPTION
# Description

This pull request includes a change to the API documentation settings in the `config/settings/base.py` file. The change modifies the permissions for serving the API documentation.

### Permissions Update:

* [`config/settings/base.py`](diffhunk://#diff-f7a16228131ae92457c22657bb33458207a7578b8cdb6ff796153916fa67a22dL377-R377): Changed the `SERVE_PERMISSIONS` setting from `IsAdminUser` to `AllowAny`, allowing unrestricted access to the API documentation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * API documentation UI (Swagger) is now accessible to all users, not just admins.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->