### PR TITLE
Update comment retrieval to show only top-level comments and adjust related tests

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -347,7 +347,7 @@ SOCIALACCOUNT_FORMS = {"signup": "core.users.forms.UserSocialSignupForm"}
 # django-rest-framework - https://www.django-rest-framework.org/api-guide/settings/
 REST_FRAMEWORK = {
     "DEFAULT_AUTHENTICATION_CLASSES": (
-        "rest_framework.authentication.BasicAuthentication",
+        # "rest_framework.authentication.BasicAuthentication",
         "rest_framework.authentication.SessionAuthentication",
         "rest_framework.authentication.TokenAuthentication",
         "rest_framework_simplejwt.authentication.JWTAuthentication",

--- a/social_media/views/post_comments.py
+++ b/social_media/views/post_comments.py
@@ -100,6 +100,7 @@ class PostCommentListView(ListCreateAPIView):
             PostComment.objects.filter(
                 post__slug=post_slug,
                 post__is_potentially_harmful=False,
+                parent__isnull=True,  # Only show top-level comments, not replies
             )
             .select_related("user__profile", "parent")
             .prefetch_related(replies_prefetch, "likes__user")


### PR DESCRIPTION
# Description

This pull request introduces changes to improve the handling of comments in the social media application by modifying the behavior to only display top-level comments and hiding replies. Additionally, a minor change was made to the authentication settings in the configuration file. Below is a summary of the most important changes:

### Changes to comment handling:

* Updated the `get_queryset` method in `social_media/views/post_comments.py` to filter out replies by adding a condition to only include top-level comments (`parent__isnull=True`).
* Modified the `test_get_comments_with_replies` test in `social_media/tests/test_views/test_post_comment_list_view.py` to verify that only top-level comments are returned, ensuring replies are hidden. Adjusted assertions to reflect this behavior. [[1]](diffhunk://#diff-af3eb927d8d5a9dddaab9623750ad293d4f43770f5d616e1240066edc0fbf9b5L403-R411) [[2]](diffhunk://#diff-af3eb927d8d5a9dddaab9623750ad293d4f43770f5d616e1240066edc0fbf9b5L431-R443)

### Changes to authentication settings:

* Commented out `BasicAuthentication` in the `REST_FRAMEWORK` settings in `config/settings/base.py`, leaving it unused but still visible for reference.