### PR TITLE
Allow '0000' code for user activation in DEBUG mode

### DIFF
--- a/accounts/serializers.py
+++ b/accounts/serializers.py
@@ -79,7 +79,7 @@ class ConfirmLoginSerializer(serializers.Serializer):
         return value
 
     def validate(self, data):
-        # Allow '000' code in DEBUG mode
+        # Allow '0000' code in DEBUG mode
         if settings.DEBUG and data["code"] == "0000":
             return data
 

--- a/accounts/serializers.py
+++ b/accounts/serializers.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 from rest_framework import serializers
 
 from accounts.models import LoginCode
@@ -78,6 +79,10 @@ class ConfirmLoginSerializer(serializers.Serializer):
         return value
 
     def validate(self, data):
+        # Allow '000' code in DEBUG mode
+        if settings.DEBUG and data["code"] == "0000":
+            return data
+
         user = User.objects.filter(username=data["phone_number"]).first()
         login_code = (
             LoginCode.objects.filter(user=user, code=data["code"]).last()

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 from django.db import transaction
 from django.http import HttpResponse
 from rest_framework import status
@@ -90,10 +91,25 @@ class ConfirmRegistrationView(UpdateAPIView):
         serializer.is_valid(raise_exception=True)
 
         user = User.objects.get(username=serializer.validated_data.get("phone_number"))
+        code = serializer.validated_data.get("code")
+
+        # Allow '000' code in DEBUG mode
+        if settings.DEBUG and code == "0000":
+            user.is_active = True
+            user.save()
+
+            token = RefreshToken.for_user(user)
+            return Response(
+                {
+                    "message": "User activated successfully",
+                    "data": {"access": str(token.access_token), "refresh": str(token)},
+                },
+                status=status.HTTP_200_OK,
+            )
 
         verification_code = VerificationCode.objects.filter(
             user=user,
-            code=serializer.validated_data.get("code"),
+            code=code,
         ).last()
 
         if not verification_code or verification_code.is_expired:

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -93,7 +93,7 @@ class ConfirmRegistrationView(UpdateAPIView):
         user = User.objects.get(username=serializer.validated_data.get("phone_number"))
         code = serializer.validated_data.get("code")
 
-        # Allow '000' code in DEBUG mode
+        # Allow '0000' code in DEBUG mode
         if settings.DEBUG and code == "0000":
             user.is_active = True
             user.save()


### PR DESCRIPTION
# Description

Allow `0000` code when debug is true.

# Local Testing Result

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/c62834e7-9f64-40cf-b671-b81bd8b2de68" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * During debug mode, users can now use the code "0000" to bypass standard verification steps when confirming login or registration.

* **Bug Fixes**
  * Improved the developer experience by allowing easier testing of authentication flows in debug environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->