### PR TITLE
Update product image field in migration: remove default value and adjust help text for clarity

### DIFF
--- a/ecommerce/admin.py
+++ b/ecommerce/admin.py
@@ -159,7 +159,6 @@ class ProductAdmin(admin.ModelAdmin):
         "created_at",
         "updated_at",
     ]
-    prepopulated_fields = {"slug": ("name",)}
     raw_id_fields = ["user"]
 
     fieldsets = (


### PR DESCRIPTION
…

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - In the product administration interface, the slug field is no longer auto-populated from the product name when adding a new product.
  - The slug remains visible as read-only in the admin; no other fields or behaviors are changed.
  - Existing products are unaffected, and editing workflows remain the same.
  - Admins will no longer see automatic slug suggestions during creation; the slug will appear as usual once available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->