### PR TITLE
Enable django-extensions in production configuration

### DIFF
--- a/config/settings/production.py
+++ b/config/settings/production.py
@@ -133,6 +133,11 @@ ADMIN_URL = env("DJANGO_ADMIN_URL")
 # ------------------------------------------------------------------------------
 # https://anymail.readthedocs.io/en/stable/installation/#installing-anymail
 INSTALLED_APPS += ["anymail"]
+
+# django-extensions
+# ------------------------------------------------------------------------------
+# https://django-extensions.readthedocs.io/en/latest/installation_instructions.html#configuration
+INSTALLED_APPS += ["django_extensions"]
 # https://docs.djangoproject.com/en/dev/ref/settings/#email-backend
 # https://anymail.readthedocs.io/en/stable/installation/#anymail-settings-reference
 # https://anymail.readthedocs.io/en/stable/esps

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -35,3 +35,7 @@ openai==1.99.9  # https://pypi.org/project/openai/
 # Custom
 pytest-cov==6.2.1
 pydantic==2.11.7
+
+# Django Extensions & Testing
+django-extensions==4.1  # https://github.com/django-extensions/django-extensions
+factory-boy==3.3.3  # https://github.com/FactoryBoy/factory_boy

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -27,9 +27,6 @@ pre-commit==4.3.0  # https://github.com/pre-commit/pre-commit
 
 # Django
 # ------------------------------------------------------------------------------
-factory-boy==3.3.3  # https://github.com/FactoryBoy/factory_boy
-
 django-debug-toolbar==6.0.0  # https://github.com/jazzband/django-debug-toolbar
-django-extensions==4.1  # https://github.com/django-extensions/django-extensions
 django-coverage-plugin==3.1.1  # https://github.com/nedbat/django_coverage_plugin
 pytest-django==4.11.1  # https://github.com/pytest-dev/pytest-django


### PR DESCRIPTION
## Summary
- Move django-extensions and factory-boy from local development requirements to base requirements
- Add django-extensions to production INSTALLED_APPS configuration  
- Enable useful Django management commands in production environment

## Test plan
- [ ] Verify production deployment works without errors
- [ ] Test that django-extensions commands are available in production
- [ ] Confirm no breaking changes to existing functionality

🤖 Generated with [Claude Code](https://claude.ai/code)