### PR TITLE
feat: disctrict api for searh

### DIFF
--- a/location/tests/test_views/test_all.py
+++ b/location/tests/test_views/test_all.py
@@ -8,8 +8,10 @@ from location.models import District
 from location.models import Province
 
 
+
 class BaseLocationTest(TestCase):
-    def setUp(self):
+    def setUp(self): 
+        
         self.country = Country.objects.create(name="Test Country", code="TC")
         self.province = Province.objects.create(
             name="Test Province",

--- a/location/tests/test_views/test_all.py
+++ b/location/tests/test_views/test_all.py
@@ -8,10 +8,8 @@ from location.models import District
 from location.models import Province
 
 
-
 class BaseLocationTest(TestCase):
-    def setUp(self): 
-        
+    def setUp(self):
         self.country = Country.objects.create(name="Test Country", code="TC")
         self.province = Province.objects.create(
             name="Test Province",

--- a/location/tests/test_views/test_all.py
+++ b/location/tests/test_views/test_all.py
@@ -56,3 +56,16 @@ class CityViewTests(BaseLocationTest):
             reverse("location:city-detail", kwargs={"pk": self.city.pk}),
         )
         assert response.status_code == status.HTTP_200_OK
+
+
+class DistrictViewTests(BaseLocationTest):
+    def test_district_list_view(self):
+        response = self.client.get(reverse("location:districts"))
+        assert response.status_code == status.HTTP_200_OK
+        self.assertContains(response, "Test District")
+
+    def test_district_detail_view(self):
+        response = self.client.get(
+            reverse("location:district-detail", kwargs={"pk": self.district.pk}),
+        )
+        assert response.status_code == status.HTTP_200_OK

--- a/location/urls.py
+++ b/location/urls.py
@@ -4,6 +4,8 @@ from location.views import CityDetailAPIView
 from location.views import CityListAPIView
 from location.views import CountryDetailAPIView
 from location.views import CountryListAPIView
+from location.views import DistrictDetailAPIView
+from location.views import DistrictListAPIView
 from location.views import ProvinceDetailAPIView
 from location.views import ProvinceListAPIView
 
@@ -22,6 +24,8 @@ urlpatterns = [
     ),
     path("cities/", CityListAPIView.as_view(), name="cities"),
     path("cities/<pk>/", CityDetailAPIView.as_view(), name="city-detail"),
+    path("districts/", DistrictListAPIView.as_view(), name="districts"),
+    path("districts/<pk>/", DistrictDetailAPIView.as_view(), name="district-detail"),
 ]
 
 app_name = "location"

--- a/location/views.py
+++ b/location/views.py
@@ -8,9 +8,11 @@ from rest_framework.permissions import AllowAny
 
 from location.models import City
 from location.models import Country
+from location.models import District
 from location.models import Province
 from location.serializers import CitySerializer
 from location.serializers import CountrySerializer
+from location.serializers import DistrictSerializer
 from location.serializers import ProvinceSerializer
 
 
@@ -76,3 +78,29 @@ class CityListAPIView(BaseLocationListAPIView):
 class CityDetailAPIView(BaseLocationDetailAPIView):
     serializer_class = CitySerializer
     queryset = City.objects.all()
+
+
+class DistrictListAPIView(BaseLocationListAPIView):
+    serializer_class = DistrictSerializer
+    queryset = (
+        District.objects.all()
+        .order_by("-name")
+        .prefetch_related("city")
+        .prefetch_related("city__province")
+        .prefetch_related("city__province__country")
+    )
+    search_fields = ["name"]
+    filterset_fields = [
+        "name",
+        "city__name",
+        "city__id",
+        "city__province__name",
+        "city__province__id",
+        "city__province__country__name",
+        "city__province__country__id",
+    ]
+
+
+class DistrictDetailAPIView(BaseLocationDetailAPIView):
+    serializer_class = DistrictSerializer
+    queryset = District.objects.all()


### PR DESCRIPTION
This pull request adds support for district-related API endpoints to the location app. It introduces new views, serializers, and URL patterns for listing and retrieving district information, as well as corresponding tests to ensure correct functionality.

### API Enhancements

* Added `DistrictListAPIView` and `DistrictDetailAPIView` classes to `location/views.py`, enabling listing and detail retrieval for districts, including search and filtering by district, city, province, and country fields.
* Registered new district endpoints in `location/urls.py` for listing all districts and retrieving details for a specific district.
* Imported `District` model and `DistrictSerializer` in `location/views.py` to support the new views.
* Imported new district views in `location/urls.py` for proper routing.

### Testing

* Added `DistrictViewTests` in `location/tests/test_views/test_all.py` to verify district list and detail endpoints return expected results.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added District resource to the Location API.
  * New endpoints: /districts/ (list) and /districts/<id>/ (detail).
  * Supports search by district name and filtering by city, province, and country fields.
  * Responses include related location context; results ordered by name.

* **Tests**
  * Introduced tests for district list and detail endpoints to verify availability and content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->