### PR TITLE
Revert "Bump uvicorn[standard] from 0.35.0 to 0.37.0"

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -7,7 +7,7 @@ hiredis==3.2.1  # https://github.com/redis/hiredis-py
 celery==5.5.3  # pyup: < 6.0  # https://github.com/celery/celery
 django-celery-beat==2.8.1  # https://github.com/celery/django-celery-beat
 flower==2.0.1  # https://github.com/mher/flower
-uvicorn[standard]==0.37.0  # https://github.com/encode/uvicorn
+uvicorn[standard]==0.35.0  # https://github.com/encode/uvicorn
 uvicorn-worker==0.3.0  # https://github.com/Kludex/uvicorn-worker
 
 # Django


### PR DESCRIPTION
Reverts UNKLAB-ID/tani-pintar-backend#315

Restore uvicorn version

<img width="1919" height="1079" alt="image" src="https://github.com/user-attachments/assets/ae934166-86c9-4610-8a46-9e05c7ebf9de" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Adjusted application server dependency version to maintain compatibility and stability across environments. This change does not alter functionality, interfaces, or behavior of the application. No updates to features, performance, or UI are included in this release. Users should not expect any visible changes during normal use. Background maintenance only; startup, requests, and error handling remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->